### PR TITLE
Update dependencies and adopt Gradio 5 message API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,10 +3,10 @@
 #
 # gradio powers the web-based interface that enables users to interact with
 # AI specification tools directly from the browser with minimal boilerplate.
-gradio==4.0.0
+gradio==5.46.1
 # requests provides a simple yet powerful HTTP client for calling external AI
 # services that do not have dedicated SDKs, ensuring consistent API handling.
-requests==2.31.0
+requests==2.32.5
 # sqlite3 is part of the Python standard library and powers lightweight local
 # storage for specifications; the entry here serves as documentation only.
 # No pip installation is required because sqlite3 ships with Python 3.
@@ -14,10 +14,10 @@ requests==2.31.0
 # python-dotenv loads environment variables from a .env file, simplifying
 # configuration management for different environments (development, staging,
 # production) without hardcoding secrets in the codebase.
-python-dotenv==1.0.1
+python-dotenv==1.1.1
 # markdown converts project specifications into Markdown-formatted text for
 # exports and previews inside the application and supporting services.
-markdown==3.5.2
+markdown==3.9
 # jinja2 renders HTML and Markdown export templates with dynamic content,
 # allowing flexible formatting of generated specification documents.
-jinja2==3.1.3
+jinja2==3.1.6


### PR DESCRIPTION
## Summary
- bump Gradio to v5.46.1 alongside newer requests, python-dotenv, markdown, and Jinja2 pins
- migrate chatbot state to Gradio 5's message objects and use generic gr.update helpers
- update demo data and event handlers to match the refreshed conversation types

## Testing
- pip install -r requirements.txt
- python - <<'PY'
import app
app.build_interface()
print("build success")
PY
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cf263411cc8325838f5d586d03efd7