### PR TITLE
Add in-memory storage option for Hugging Face deployments

### DIFF
--- a/app.py
+++ b/app.py
@@ -48,7 +48,10 @@ LOGGER = logging.getLogger(__name__)
 # Instantiate configuration, database manager, and AI client when the module is
 # imported. This ensures shared state is reused across Gradio requests.
 CONFIG: AppConfig = AppConfig.from_environment()
-DB_MANAGER = DatabaseManager(database_path=CONFIG.database_path)
+DB_MANAGER = DatabaseManager(
+    database_path=CONFIG.database_path,
+    persistence_enabled=CONFIG.persistence_enabled,
+)
 AI = AIClient(config=CONFIG)
 
 # Category definitions used throughout validation and reporting flows. The order


### PR DESCRIPTION
## Summary
- add a persistence toggle to `AppConfig` so Spaces default to in-memory storage while local runs still use SQLite
- extend the database manager with an in-memory implementation and guard module-level initialisation for read-only environments
- initialise the Gradio app with the new persistence flag so storage behaviour matches the environment

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cfe30d5d2c8325850ece37a41ee982